### PR TITLE
Add check for Command modifier

### DIFF
--- a/Syndiesis/Controls/Editor/CodeEditor.axaml.cs
+++ b/Syndiesis/Controls/Editor/CodeEditor.axaml.cs
@@ -674,7 +674,7 @@ public partial class CodeEditor : UserControl
     {
         var modifiers = e.KeyModifiers;
 
-        bool hasControl = modifiers.HasFlag(KeyModifiers.Control);
+        bool hasControl = modifiers.HasFlag(OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control);
         bool hasShift = modifiers.HasFlag(KeyModifiers.Shift);
 
         switch (e.Key)


### PR DESCRIPTION
Most of the modifiers work fine except Ctrl+V (Ctrl+Shift+V works as intended). Clipboard works fine so I have no idea why It shouldn't work.