### PR TITLE
Highlight `TypedConstant` values in editor

### DIFF
--- a/Syndiesis/Controls/AnalysisVisualization/AnalysisTreeListView.axaml.cs
+++ b/Syndiesis/Controls/AnalysisVisualization/AnalysisTreeListView.axaml.cs
@@ -163,7 +163,7 @@ public partial class AnalysisTreeListView : UserControl, IAnalysisNodeHoverManag
             if (parentNode is null)
                 return current;
 
-            if (current.NodeLine.AnalysisNodeKind != targetKind)
+            if (MatchesNodeKind(current.NodeLine.AnalysisNodeKind, targetKind))
             {
                 goto next;
             }
@@ -180,6 +180,18 @@ public partial class AnalysisTreeListView : UserControl, IAnalysisNodeHoverManag
         next:
             current = parentNode;
         }
+    }
+
+    private static bool MatchesNodeKind(AnalysisNodeKind value, AnalysisNodeKind target)
+    {
+        if (target is AnalysisNodeKind.Symbol)
+        {
+            return value
+                is AnalysisNodeKind.Attribute
+                or AnalysisNodeKind.Symbol;
+        }
+
+        return value == target;
     }
 
     protected override void OnPointerExited(PointerEventArgs e)
@@ -408,7 +420,7 @@ public partial class AnalysisTreeListView : UserControl, IAnalysisNodeHoverManag
             if (current is null)
                 return null;
 
-            if (current.NodeLine.AnalysisNodeKind == TargetAnalysisNodeKind)
+            if (MatchesNodeKind(current.NodeLine.AnalysisNodeKind, TargetAnalysisNodeKind))
             {
                 return current;
             }
@@ -459,7 +471,7 @@ public partial class AnalysisTreeListView : UserControl, IAnalysisNodeHoverManag
                 .Where(s =>
                 {
                     var nodeLine = s.NodeLine;
-                    return nodeLine.AnalysisNodeKind == TargetAnalysisNodeKind
+                    return MatchesNodeKind(nodeLine.AnalysisNodeKind, TargetAnalysisNodeKind)
                         && nodeLine.DisplaySpan.Contains(span);
                 })
                 .ToArray();

--- a/Syndiesis/Core/AttributeDataViewModel.cs
+++ b/Syndiesis/Core/AttributeDataViewModel.cs
@@ -1,0 +1,176 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.VisualBasic;
+using System.Collections.Immutable;
+using System.Threading;
+
+namespace Syndiesis.Core;
+
+public sealed class AttributeDataViewModel
+{
+    public required AttributeData AttributeData { get; init; }
+    public required ImmutableArray<LinkedAttributeArgument> ConstructorArguments { get; init; }
+    public required ImmutableArray<LinkedAttributeArgument> NamedArguments { get; init; }
+
+    public ImmutableArray<LinkedAttributeArgument> AllArguments
+    {
+        get
+        {
+            return
+            [
+                .. ConstructorArguments,
+                .. NamedArguments,
+            ];
+        }
+    }
+
+    private AttributeDataViewModel() { }
+
+    public static AttributeDataViewModel? Create(
+        AttributeData data,
+        CancellationToken cancellationToken = default)
+    {
+        var syntax = data.ApplicationSyntaxReference?.GetSyntax(cancellationToken);
+        if (syntax is null)
+            return null;
+
+        if (data.HasNoArguments())
+            return Empty(data);
+
+        switch (syntax)
+        {
+            case CSharpSyntaxNode csAttribute:
+                return CreateCSharpModel(data, csAttribute);
+            case VisualBasicSyntaxNode vbAttribute:
+                return CreateVisualBasicModel(data, vbAttribute);
+            default:
+                return null;
+        }
+    }
+
+    private static AttributeDataViewModel Empty(AttributeData data)
+    {
+        return new()
+        {
+            AttributeData = data,
+            ConstructorArguments = [],
+            NamedArguments = [],
+        };
+    }
+
+    private static AttributeDataViewModel? CreateCSharpModel(
+        AttributeData data, CSharpSyntaxNode csAttribute)
+    {
+        var attribute = csAttribute as Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax;
+        if (attribute is null)
+            return null;
+
+        var argumentList = attribute.ArgumentList;
+        if (argumentList is null)
+            return Empty(data);
+
+        var arguments = argumentList.Arguments;
+        if (arguments is [])
+            return Empty(data);
+
+        return ConstructFromArguments(data, arguments);
+    }
+
+    private static AttributeDataViewModel? CreateVisualBasicModel(
+        AttributeData data, VisualBasicSyntaxNode vbAttribute)
+    {
+        var attribute = vbAttribute as Microsoft.CodeAnalysis.VisualBasic.Syntax.AttributeSyntax;
+        if (attribute is null)
+            return null;
+
+        var argumentList = attribute.ArgumentList;
+        if (argumentList is null)
+            return Empty(data);
+
+        var arguments = argumentList.Arguments;
+        if (arguments is [])
+            return Empty(data);
+
+        return ConstructFromArguments(data, arguments);
+    }
+
+    private static AttributeDataViewModel ConstructFromArguments<TSyntax>(
+        AttributeData data, SeparatedSyntaxList<TSyntax> arguments)
+        where TSyntax : SyntaxNode
+    {
+        ImmutableArray<LinkedAttributeArgument> regularArguments = [];
+        ImmutableArray<LinkedAttributeArgument> namedArguments = [];
+
+        if (data.ConstructorArguments is not [] and var constructorArgumentsData)
+        {
+            var regularArgumentsBuilder = ImmutableArray.CreateBuilder<LinkedAttributeArgument>(
+                constructorArgumentsData.Length);
+
+            // We always have a constructor if we have constructor arguments
+            // We expect a potential breaking API change that returns a null
+            // constructor with a non-empty argument list, in which case we show the param order
+            var constructor = data.AttributeConstructor;
+            var constructorParameters = constructor?.Parameters;
+            var mappingKind = 
+                constructorParameters is not null
+                ? AttributeArgumentNameMappingKind.Parameter
+                : AttributeArgumentNameMappingKind.ParameterIndex;
+            for (int i = 0; i < constructorArgumentsData.Length; i++)
+            {
+                var argumentSyntax = arguments[i];
+                var value = constructorArgumentsData[i];
+                var parameter = constructorParameters?[i];
+                var displayName = parameter?.Name ?? i.ToString();
+                regularArgumentsBuilder.Add(new(
+                    argumentSyntax,
+                    displayName,
+                    value,
+                    mappingKind));
+            }
+            regularArguments = regularArgumentsBuilder.ToImmutable();
+        }
+
+        if (data.NamedArguments is not [] and var namedArgumentsData)
+        {
+            var namedArgumentsBuilder = ImmutableArray.CreateBuilder<LinkedAttributeArgument>(
+                namedArgumentsData.Length);
+
+            int offset = data.ConstructorArguments.Length;
+
+            for (int i = 0; i < namedArgumentsData.Length; i++)
+            {
+                var argumentSyntax = arguments[i + offset];
+                var kvp = namedArgumentsData[i];
+                var name = kvp.Key;
+                var value = kvp.Value;
+                namedArgumentsBuilder.Add(new(
+                    argumentSyntax,
+                    name,
+                    value,
+                    AttributeArgumentNameMappingKind.Named));
+            }
+            namedArguments = namedArgumentsBuilder.ToImmutable();
+        }
+
+        return new()
+        {
+            AttributeData = data,
+            ConstructorArguments = regularArguments,
+            NamedArguments = namedArguments,
+        };
+    }
+
+    public sealed record class LinkedAttributeArgument(
+        SyntaxNode ArgumentSyntax,
+        string Name,
+        TypedConstant Value,
+        AttributeArgumentNameMappingKind MappingKind)
+        ;
+
+    public enum AttributeArgumentNameMappingKind
+    {
+        Parameter,
+        ParameterIndex,
+        Named,
+    }
+}

--- a/Syndiesis/Core/DisplayAnalysis/BaseAnalysisNodeCreator.cs
+++ b/Syndiesis/Core/DisplayAnalysis/BaseAnalysisNodeCreator.cs
@@ -705,7 +705,7 @@ static string Code(string type)
         inlines.Children!.Add(new(single));
     }
 
-    private static Run CreateValueSplitterRun()
+    protected static Run CreateValueSplitterRun()
     {
         return Run(":  ", CommonStyles.SplitterBrush);
     }
@@ -863,7 +863,7 @@ static string Code(string type)
         int count, string propertyName)
     {
         var propertyGroup = new SingleRunInline(Run(propertyName, CommonStyles.PropertyBrush));
-        var separator = Run(":  ", CommonStyles.SplitterBrush);
+        var separator = CreateValueSplitterRun();
         var countRun = Run(count.ToString(), CommonStyles.RawValueBrush);
         return new ComplexGroupedRunInline([
             new(propertyGroup),
@@ -1311,7 +1311,7 @@ partial class BaseAnalysisNodeCreator
 
             return new ComplexGroupedRunInline([
                 new(BasicValueInline(key)),
-                Run(":  ", CommonStyles.SplitterBrush),
+                CreateValueSplitterRun(),
                 new(BasicValueInline(value)),
             ]);
         }

--- a/Syndiesis/Core/DisplayAnalysis/SyntaxObjectInfo.cs
+++ b/Syndiesis/Core/DisplayAnalysis/SyntaxObjectInfo.cs
@@ -113,6 +113,12 @@ public sealed record SyntaxObjectInfo(
             case AttributeData attribute:
                 return attribute.GetAttributeApplicationSyntax()?.SyntaxTree;
 
+            case AttributeDataViewModel attributeModel:
+                return GetSyntaxTree(attributeModel.NamedArguments);
+
+            case AttributeDataViewModel.LinkedAttributeArgument attributeArgument:
+                return GetSyntaxTree(attributeArgument.ArgumentSyntax);
+
             // Operation
             case IOperation operation:
                 return operation.Syntax.SyntaxTree;
@@ -177,6 +183,12 @@ public sealed record SyntaxObjectInfo(
             case AttributeData attribute:
                 return attribute.ApplicationSyntaxReference
                     ?.Span ?? InvalidTextSpan;
+
+            case AttributeDataViewModel attributeModel:
+                return GetSpan(attributeModel.NamedArguments);
+
+            case AttributeDataViewModel.LinkedAttributeArgument attributeArgument:
+                return GetSpan(attributeArgument.ArgumentSyntax);
 
             // Operation
             case IOperation operation:
@@ -243,6 +255,12 @@ public sealed record SyntaxObjectInfo(
             case AttributeData attribute:
                 return attribute.GetAttributeApplicationSyntax()
                     ?.FullSpan ?? InvalidTextSpan;
+
+            case AttributeDataViewModel attributeModel:
+                return GetFullSpan(attributeModel.NamedArguments);
+
+            case AttributeDataViewModel.LinkedAttributeArgument attributeArgument:
+                return GetFullSpan(attributeArgument.ArgumentSyntax);
 
             // Operation
             case IOperation operation:

--- a/Syndiesis/Core/ISingleTreeCompilationSource.cs
+++ b/Syndiesis/Core/ISingleTreeCompilationSource.cs
@@ -19,3 +19,4 @@ public interface ISingleTreeCompilationSource
 
     public void SetSource(string source, CancellationToken cancellationToken);
 }
+

--- a/Syndiesis/Core/RoslynExtensions.cs
+++ b/Syndiesis/Core/RoslynExtensions.cs
@@ -306,4 +306,11 @@ public static class RoslynExtensions
 
         return ConversionUnion.None;
     }
+
+    public static bool HasNoArguments(this AttributeData attribute)
+    {
+        return attribute.ConstructorArguments is []
+            && attribute.NamedArguments is []
+            ;
+    }
 }


### PR DESCRIPTION
Closes #75 

In this implementation, Syndiesis wraps each `TypedConstant` instance returned from `ConstructorArguments` and `NamedArguments` into a model mapping the value to a name and its argument syntax. The user won't be seeing the wrapped model.