### PR TITLE
Better handle crashes

### DIFF
--- a/Syndiesis/App.axaml.cs
+++ b/Syndiesis/App.axaml.cs
@@ -121,7 +121,9 @@ public partial class App : Application
             .WriteTo.File(
                 "logs/syndiesis-main.txt",
                 rollingInterval: RollingInterval.Day,
-                outputTemplate: LoggerExtensionsEx.DefaultOutputTemplate)
+                outputTemplate: LoggerExtensionsEx.DefaultOutputTemplate,
+                buffered: true,
+                flushToDiskInterval: TimeSpan.FromSeconds(2))
             .CreateLogger()
             ;
 

--- a/Syndiesis/Controls/Editor/CSharpRoslynColorizer.cs
+++ b/Syndiesis/Controls/Editor/CSharpRoslynColorizer.cs
@@ -27,7 +27,15 @@ public sealed partial class CSharpRoslynColorizer(CSharpSingleTreeCompilationSou
 
         cancellationTokenFactory.Cancel();
 
-        PerformColorization(line, cancellationTokenFactory.CurrentToken);
+        try
+        {
+            PerformColorization(line, cancellationTokenFactory.CurrentToken);
+        }
+        catch (Exception ex)
+        when (ex is not OperationCanceledException)
+        {
+            App.Current.ExceptionListener.HandleException(ex, "Colorization failed");
+        }
     }
 
     private void PerformColorization(

--- a/Syndiesis/Controls/Editor/CodeEditor.axaml
+++ b/Syndiesis/Controls/Editor/CodeEditor.axaml
@@ -25,14 +25,41 @@
         <RowDefinition Height="20"/>
       </Grid.RowDefinitions>
 
-      <controls:SyndiesisTextEditor
-        Name="textEditor"
-        Text="Hello AvaloniaEdit from Syndiesis!"
-        ShowLineNumbers="True"
-        HorizontalScrollBarVisibility="Hidden"
-        VerticalScrollBarVisibility="Hidden"
-        FontFamily="{StaticResource FiraCodeFontFamily}"
-      />
+      <Grid>
+        <controls:SyndiesisTextEditor
+          Name="textEditor"
+          Text="Hello AvaloniaEdit from Syndiesis!"
+          ShowLineNumbers="True"
+          HorizontalScrollBarVisibility="Hidden"
+          VerticalScrollBarVisibility="Hidden"
+          FontFamily="{StaticResource FiraCodeFontFamily}"
+        />
+
+        <StackPanel
+          Name="diagnosticsUnavailableDisplay"
+          IsVisible="false"
+          HorizontalAlignment="Right"
+          VerticalAlignment="Bottom">
+          <TextBlock
+            Margin="0 0 5 -3"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Bottom"
+            FontSize="22"
+            Foreground="#AAAA4444"
+            FontFamily="{StaticResource AptosFontFamily}"
+            Text="DIAGNOSTICS UNAVAILABLE">
+          </TextBlock>
+          <TextBlock
+            Margin="0 0 5 3"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Bottom"
+            FontSize="14"
+            Foreground="#80AA4444"
+            FontFamily="{StaticResource AptosFontFamily}"
+            Text="due to a compiler exception">
+          </TextBlock>
+        </StackPanel>
+      </Grid>
 
       <Panel
         Background="#003034"

--- a/Syndiesis/Controls/Editor/CodeEditor.axaml.cs
+++ b/Syndiesis/Controls/Editor/CodeEditor.axaml.cs
@@ -110,6 +110,15 @@ public partial class CodeEditor : UserControl
         }
     }
 
+    public bool DiagnosticsUnavailable
+    {
+        get => diagnosticsUnavailableDisplay.IsVisible;
+        set
+        {
+            diagnosticsUnavailableDisplay.IsVisible = value;
+        }
+    }
+
     public event EventHandler? TextChanged
     {
         add => textEditor.Document.TextChanged += value;

--- a/Syndiesis/Controls/Editor/DiagnosticsLayer.cs
+++ b/Syndiesis/Controls/Editor/DiagnosticsLayer.cs
@@ -30,9 +30,18 @@ public sealed partial class DiagnosticsLayer : SyndiesisTextEditorLayer
         if (!Enabled)
             return;
 
-        var diagnostics = CodeEditor.CompilationSource?.CurrentSource.Diagnostics;
-        if (diagnostics is null)
+        var currentSource = CodeEditor.CompilationSource?.CurrentSource;
+        if (currentSource is null)
+        {
             return;
+        }
+
+        var diagnostics = currentSource.GetDiagnostics();
+
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            CodeEditor.DiagnosticsUnavailable = currentSource.DiagnosticsUnavailable;
+        });
 
         var firstLineIndex = Math.Max(TextView.GetFirstVisibleLine() - 1, 0);
         var lastLineIndex = TextView.GetLastVisibleLine();

--- a/Syndiesis/Controls/Editor/QuickInfo/VisualBasicFallbackSymbolDefinitionInlinesCreator.cs
+++ b/Syndiesis/Controls/Editor/QuickInfo/VisualBasicFallbackSymbolDefinitionInlinesCreator.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.CodeAnalysis;
+using Syndiesis.Controls.Inlines;
+using System;
+
+namespace Syndiesis.Controls.Editor.QuickInfo;
+
+[Obsolete("This is a placeholder creator only meant to be used for unimplemented symbol kinds")]
+internal sealed class VisualBasicFallbackSymbolDefinitionInlinesCreator(
+    VisualBasicSymbolDefinitionInlinesCreatorContainer parentContainer)
+    : BaseVisualBasicSymbolDefinitionInlinesCreator<ISymbol>(parentContainer)
+{
+    public override GroupedRunInline.IBuilder CreateSymbolInline(ISymbol symbol)
+    {
+        return new SimpleGroupedRunInline.Builder();
+    }
+}

--- a/Syndiesis/Controls/Editor/QuickInfo/VisualBasicSymbolDefinitionInlinesCreatorContainer.cs
+++ b/Syndiesis/Controls/Editor/QuickInfo/VisualBasicSymbolDefinitionInlinesCreatorContainer.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis;
-using System;
 
 namespace Syndiesis.Controls.Editor.QuickInfo;
 
@@ -7,12 +6,14 @@ public sealed class VisualBasicSymbolDefinitionInlinesCreatorContainer
     : BaseSymbolDefinitionInlinesCreatorContainer
 {
     public readonly VisualBasicNamedTypeSymbolDefinitionInlinesCreator NamedTypeCreator;
+    private readonly VisualBasicFallbackSymbolDefinitionInlinesCreator _fallback;
 
     public VisualBasicSymbolDefinitionInlinesCreatorContainer(
         ISymbolInlinesRootCreatorContainer rootContainer)
         : base(rootContainer)
     {
         NamedTypeCreator = new(this);
+        _fallback = new(this);
     }
 
     protected override ISymbolItemInlinesCreator FallbackCreatorForSymbol<TSymbol>(TSymbol symbol)
@@ -23,7 +24,7 @@ public sealed class VisualBasicSymbolDefinitionInlinesCreatorContainer
                 return NamedTypeCreator;
 
             default:
-                throw new ArgumentException("The symbol type is not supported.", nameof(symbol));
+                return _fallback;
         }
     }
 }

--- a/Syndiesis/Controls/Editor/VisualBasicRoslynColorizer.cs
+++ b/Syndiesis/Controls/Editor/VisualBasicRoslynColorizer.cs
@@ -27,7 +27,15 @@ public sealed partial class VisualBasicRoslynColorizer(
 
         cancellationTokenFactory.Cancel();
 
-        PerformColorization(line, cancellationTokenFactory.CurrentToken);
+        try
+        {
+            PerformColorization(line, cancellationTokenFactory.CurrentToken);
+        }
+        catch (Exception ex)
+        when (ex is not OperationCanceledException)
+        {
+            App.Current.ExceptionListener.HandleException(ex, "Colorization failed");
+        }
     }
 
     private void PerformColorization(

--- a/Syndiesis/Core/ISingleTreeCompilationSource.cs
+++ b/Syndiesis/Core/ISingleTreeCompilationSource.cs
@@ -5,18 +5,19 @@ namespace Syndiesis.Core;
 
 public interface ISingleTreeCompilationSource
 {
+    public bool DiagnosticsUnavailable { get; }
+
     public string LanguageName { get; }
 
     public Compilation Compilation { get; }
     public SyntaxTree? Tree { get; }
     public SemanticModel? SemanticModel { get; }
 
-    public DiagnosticsCollection Diagnostics { get; }
-
     public RoslynLanguageVersion LanguageVersion { get; }
+
+    public DiagnosticsCollection GetDiagnostics();
 
     public void AdjustLanguageVersion(RoslynLanguageVersion version);
 
     public void SetSource(string source, CancellationToken cancellationToken);
 }
-

--- a/Syndiesis/ExceptionListener.cs
+++ b/Syndiesis/ExceptionListener.cs
@@ -1,5 +1,6 @@
 ﻿using Serilog;
 using System;
+using System.Threading.Tasks;
 
 namespace Syndiesis;
 
@@ -8,6 +9,12 @@ public sealed class ExceptionListener
     public event Action<Exception>? ExceptionHandled;
 
     public void HandleException(Exception ex, string message)
+    {
+        Task.Run(() => RunHandleException(ex, message))
+            .ConfigureAwait(false);
+    }
+
+    private void RunHandleException(Exception ex, string message)
     {
         if (ex is StackOverflowException or InsufficientExecutionStackException)
         {

--- a/Syndiesis/ExceptionListener.cs
+++ b/Syndiesis/ExceptionListener.cs
@@ -9,6 +9,11 @@ public sealed class ExceptionListener
 
     public void HandleException(Exception ex, string message)
     {
+        if (ex is StackOverflowException or InsufficientExecutionStackException)
+        {
+            var replacement = new Exception($"An exception of type {ex} was thrown");
+            ex = replacement;
+        }
         Log.Logger.Error(ex, message);
         ExceptionHandled?.Invoke(ex);
     }

--- a/Syndiesis/Views/MainView.axaml.cs
+++ b/Syndiesis/Views/MainView.axaml.cs
@@ -216,7 +216,8 @@ public partial class MainView : UserControl
         var linePosition = new LinePosition(
             documentPosition.Line - 1,
             documentPosition.Column - 1);
-        var diagnostics = codeEditor.CompilationSource?.CurrentSource.Diagnostics
+        var diagnostics = codeEditor.CompilationSource?.CurrentSource
+            .GetDiagnostics()
             .DiagnosticsAtPosition(linePosition)
             .ToImmutableArray()
             ?? [];


### PR DESCRIPTION
Closes #100

Only a message is shown on the bottom right corner of the code editor whenever a compiler exception occurs, causing exceptions in subsequent compilation-related queries:
![image](https://github.com/user-attachments/assets/29765eea-dbfe-4679-8013-ddc18040b2f9)

Exceptions are properly handled and logged for further inspection. The exception information is not directly visible in the program.