### PR TITLE
Upgrade to Avalonia 11.3

### DIFF
--- a/Syndiesis/Controls/AnalysisVisualization/AnalysisTreeListView.axaml.cs
+++ b/Syndiesis/Controls/AnalysisVisualization/AnalysisTreeListView.axaml.cs
@@ -85,7 +85,7 @@ public partial class AnalysisTreeListView : UserControl, IAnalysisNodeHoverManag
         using (verticalScrollBar.BeginUpdateBlock())
         {
             verticalScrollBar.MaxValue = node.Bounds.Height + extraScrollHeight;
-            verticalScrollBar.StartPosition = -Canvas.GetTop(topLevelNodeContent);
+            verticalScrollBar.StartPosition = -Canvas.GetTop(topLevelNodeContent).ZeroOnNaN();
             verticalScrollBar.EndPosition = verticalScrollBar.StartPosition + contentCanvas.Bounds.Height;
             verticalScrollBar.SetAvailableScrollOnScrollableWindow();
         }
@@ -93,7 +93,7 @@ public partial class AnalysisTreeListView : UserControl, IAnalysisNodeHoverManag
         using (horizontalScrollBar.BeginUpdateBlock())
         {
             horizontalScrollBar.MaxValue = Math.Max(node.Bounds.Width - extraScrollWidth, 0);
-            horizontalScrollBar.StartPosition = -Canvas.GetLeft(topLevelNodeContent);
+            horizontalScrollBar.StartPosition = -Canvas.GetLeft(topLevelNodeContent).ZeroOnNaN();
             horizontalScrollBar.EndPosition = horizontalScrollBar.StartPosition + contentCanvas.Bounds.Width;
             horizontalScrollBar.SetAvailableScrollOnScrollableWindow();
         }

--- a/Syndiesis/Controls/Editor/QuickInfo/_Docs.cs
+++ b/Syndiesis/Controls/Editor/QuickInfo/_Docs.cs
@@ -21,13 +21,13 @@ The planned structure is:
     - Extras
     - Docs
     - Commons
-	- Member Container
+    - Member Container
   - VB container
     - Definition
     - Extras
     - Docs
     - Commons
-	- Member Container
+    - Member Container
 
 - Definition
   - One for each symbol
@@ -45,13 +45,13 @@ The planned structure is:
   - Simple reference to another symbol, almost equivalent to minimal display string
     This will be used by all the other creators to refer to another symbol without
     expanding on its extras
-	This is most useful for types being described anywhere, and referred symbols in
-	the docs
+    This is most useful for types being described anywhere, and referred symbols in
+    the docs
 - Member Container
   - Displays information about the containers the member is a part of
     - Member symbols (modules, namespaces, types, methods, fields, properties and events)
-	  display their containers' information fully
+      display their containers' information fully
     - Non-members (locals, parameters, etc.) may contain limited information about their
-	  containing symbol; preferably the method they are contained in
+      containing symbol; preferably the method they are contained in
 
 #endif

--- a/Syndiesis/Controls/HorizontalScrollBar.axaml.cs
+++ b/Syndiesis/Controls/HorizontalScrollBar.axaml.cs
@@ -27,10 +27,8 @@ public partial class HorizontalScrollBar : BaseScrollBar
         var position = e.GetPosition(draggableRectangle);
         var dimension = position.X;
         var dimensionLength = draggableRectangleCanvas.Bounds.Width;
-        var left = Canvas.GetLeft(draggableRectangle);
         var width = draggableRectangle.Width;
         var centerOffset = width / 2;
-        var offset = left;
         var end = width;
         HandleDraggable(e, dimension, dimensionLength, centerOffset, end);
     }

--- a/Syndiesis/Controls/VerticalScrollBar.axaml.cs
+++ b/Syndiesis/Controls/VerticalScrollBar.axaml.cs
@@ -27,7 +27,6 @@ public partial class VerticalScrollBar : BaseScrollBar
         var position = e.GetPosition(draggableRectangle);
         var dimension = position.Y;
         var dimensionLength = draggableRectangleCanvas.Bounds.Height;
-        var top = Canvas.GetTop(draggableRectangle);
         var height = draggableRectangle.Height;
         var centerOffset = height / 2;
         var end = height;

--- a/Syndiesis/Syndiesis.csproj
+++ b/Syndiesis/Syndiesis.csproj
@@ -39,14 +39,14 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.10" />
-    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.6" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.10" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.10" />
+    <PackageReference Include="Avalonia" Version="11.3.0" />
+    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.0" />
     <PackageReference Include="Avalonia.Diagnostics" Condition="'$(Configuration)'=='Allow Dev Errors'">
       <Version>11.0.10</Version>
     </PackageReference>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.10" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Garyon" Version="0.4.1" />
     <PackageReference Include="Jamarino.IntervalTree" Version="1.2.1" />

--- a/Syndiesis/Utilities/ConvenienceExtensions.cs
+++ b/Syndiesis/Utilities/ConvenienceExtensions.cs
@@ -55,6 +55,11 @@ public static class ConvenienceExtensions
         return (int)Math.Round(value);
     }
 
+    public static double ZeroOnNaN(this double value)
+    {
+        return value is double.NaN ? 0 : value;
+    }
+
     public static bool IsEmpty<T>(this IReadOnlyList<T> source)
     {
         var genericDefinition = source.GetType().GetGenericTypeDefinitionOrSame();


### PR DESCRIPTION
## Impact

The application seems smoother even in larger tree anlayses, with also a faster startup time.

## Breaking Changes

The only breaking change was `Canvas.GetXyz()` returning NaN at first, breaking scroll forever. Now the value is normalized to 0, restoring proper scrolling functionality in the analysis tree node view.